### PR TITLE
fix: exclude css files from side effect for imports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: Cache Node Modules
         uses: actions/cache@v2
         env:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "sideEffects": [
+    "*.css"
+  ],
   "main": "build/index.js",
   "types": "build/esm/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
```
Note that any imported file is subject to tree shaking. This means if you use something like css-loader in your project and import a CSS file, it needs to be added to the side effect list so it will not be unintentionally dropped in production mode:
```
- https://webpack.js.org/guides/tree-shaking/
