### PR TITLE
fix: source loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,13 @@ module.exports = {
           loader: "babel-loader",
         },
       },
+      // https://github.com/storybookjs/storybook/issues/10179#issuecomment-602390300
+      {
+        test: /\.(stories|story)\.[tj]sx?$/,
+        loader: require.resolve("@storybook/source-loader"),
+        exclude: [/node_modules/],
+        enforce: "pre",
+      },
       {
         test: /\.css$/i,
         use: ["style-loader", "css-loader"],


### PR DESCRIPTION
- custom rules overwriting default source-loader, causing `No code available` in documentation
- add loader back in

![Screenshot 2021-03-25 at 3 51 43 PM](https://user-images.githubusercontent.com/4774314/112437613-1905af80-8d82-11eb-968c-27738b2e0f4f.png)
![Screenshot 2021-03-25 at 3 54 04 PM](https://user-images.githubusercontent.com/4774314/112437838-58340080-8d82-11eb-92ca-c62aaeb68703.png)
