### PR TITLE
fix: nav bar drop down width

### DIFF
--- a/src/components/NavigationBar/NavigationBar.mock.tsx
+++ b/src/components/NavigationBar/NavigationBar.mock.tsx
@@ -28,6 +28,11 @@ export const MockLeftNavItems: NavigationItem[] = [
         label: "FAQ",
         path: "/faq",
       },
+      {
+        id: "guidelines",
+        label: "Guidelines (Non-Ethereum)",
+        path: "/guidelines",
+      },
     ],
   },
   {

--- a/src/components/NavigationBar/NavigationBarItem/NavigationBarItem.tsx
+++ b/src/components/NavigationBar/NavigationBarItem/NavigationBarItem.tsx
@@ -105,7 +105,7 @@ const DropDownList: FunctionComponent<{ item: NavType.NavigationDropDownList }> 
       </div>
       {isOpen && (
         <div
-          className={`w-full z-30 lg:left-0 lg:absolute lg:-bottom-0 lg:transform lg:translate-y-full text-sm font-bold`}
+          className={`w-max min-w-full z-30 lg:left-0 lg:absolute lg:-bottom-0 lg:transform lg:translate-y-full text-sm font-bold`}
         >
           <div className={`bg-white rounded-md lg:shadow-dropdown`}>
             {item.dropdownItems?.map((dropdownItem: NavType.NavigationDropDownItems, index: number) => {


### PR DESCRIPTION
## Summary

Update drop down width to be one line if words that are too long

## Changes

- update drop down width to have min width 100% and width of max-content to not cut the words in half

