### PR TITLE
refactor: changed globalObject to this to allow for ssr

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
     filename: "index.js",
     libraryTarget: "umd",
     library: "tradetrustComponentUI",
+    globalObject: "this",
   },
   externals: {
     react: "react",


### PR DESCRIPTION
## Summary

To allow tradetrust-ui-components to work within nextjs apps without having to dynamic import every component

## Changes

changed output.globalObject to "this" to allow components to be available on the server and the frontend

See [here](https://webpack.js.org/configuration/output/#outputglobalobject)

