### PR TITLE
feat: moving toggle component to be shared between 2 repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25706,8 +25706,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
             "tar": "^6.1.0"
           }
         },

--- a/src/components/UI/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/components/UI/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -1,0 +1,15 @@
+import React, { useState, FunctionComponent } from "react";
+import { ToggleSwitch } from "./ToggleSwitch";
+
+export default {
+  title: "UI/ToggleSwitch",
+  component: ToggleSwitch,
+  parameters: {
+    componentSubtitle: "ToggleSwitch",
+  },
+};
+
+export const Default: FunctionComponent = () => {
+  const [toggleValue, setToggleValue] = useState(false);
+  return <ToggleSwitch isOn={toggleValue} handleToggle={() => setToggleValue(!toggleValue)} />;
+};

--- a/src/components/UI/ToggleSwitch/ToggleSwitch.test.tsx
+++ b/src/components/UI/ToggleSwitch/ToggleSwitch.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { ToggleSwitch } from "./ToggleSwitch";
+
+describe("ToggleSwitch", () => {
+  it("should fire handleToggle when clicked", () => {
+    const mockHandleToggle = jest.fn();
+    render(<ToggleSwitch isOn={true} handleToggle={mockHandleToggle} />);
+    fireEvent.click(screen.getByTestId("toggle-switch"));
+    expect(mockHandleToggle).toHaveBeenCalled(); // eslint-disable-line jest/prefer-called-with
+  });
+  it("should display `ON` when isOn is true", () => {
+    render(<ToggleSwitch isOn={true} handleToggle={() => {}} />);
+    const toggle: any = screen.getByTestId("toggle-switch");
+    expect(toggle.checked).toBeTruthy(); // eslint-disable-line jest/no-truthy-falsy
+  });
+  it("should display `OFF` when isOn is false", () => {
+    render(<ToggleSwitch isOn={false} handleToggle={() => {}} />);
+    const toggle: any = screen.getByTestId("toggle-switch");
+    expect(toggle.checked).toBeFalsy(); // eslint-disable-line jest/no-truthy-falsy
+  });
+});

--- a/src/components/UI/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/UI/ToggleSwitch/ToggleSwitch.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from "react";
+
+export interface ToggleProps {
+  isOn: boolean;
+  handleToggle: () => void;
+}
+/**
+ * ToggleSwitch is a controlled component, depending on the state it is in,
+ * it will render the on or off text accordingly
+ * @param isOn state of toggle
+ * @param handleToggle toggle handler, a callback that invokes if the state
+ * changes
+ */
+export const ToggleSwitch: FunctionComponent<ToggleProps> = ({ isOn, handleToggle }) => {
+  return (
+    <label data-testid="toggle-switch-label" className="flex items-center cursor-pointer">
+      <div className="relative">
+        <input checked={isOn} className="hidden" onChange={handleToggle} type="checkbox" data-testid="toggle-switch" />
+        <div className={`block ${isOn ? `bg-emerald` : `bg-cloud-200`} w-16 h-8 rounded-2xl`} />
+        <div
+          className={`w-full absolute top-1 transform duration-100 ${
+            isOn ? `right-2 translate-x-2/3` : `left-1 translate-x-0`
+          }`}
+        >
+          <div className={`dot rounded-xl bg-white w-6 h-6`} />
+        </div>
+        <div className={`text-sm absolute top-1.5 right-1.5 text-white${isOn ? " hidden" : ""}`}>OFF</div>
+        <div className={`text-sm absolute top-1.5 left-1.5 text-white${isOn ? "" : " hidden"}`}>ON</div>
+      </div>
+    </label>
+  );
+};

--- a/src/components/UI/ToggleSwitch/index.tsx
+++ b/src/components/UI/ToggleSwitch/index.tsx
@@ -1,0 +1,1 @@
+export * from "./ToggleSwitch";


### PR DESCRIPTION
## Summary

What is the background of this pull request?
- moving toggle component from doc-creator to ui-components to be shared
- moved tests
- moved stories
- added abit of component documentation


