### PR TITLE
fix: overlay align top

### DIFF
--- a/src/components/UI/Overlay/OverlayContent/OverlayContent.tsx
+++ b/src/components/UI/Overlay/OverlayContent/OverlayContent.tsx
@@ -33,9 +33,9 @@ export const OverlayContent: FunctionComponent<OverlayContentProps> = ({
           }}
         >
           <div className="text-cloud-900">
-            <div className="flex flex-nowrap items-center mb-2">
+            <div className="flex flex-nowrap content-center items-start mb-2">
               {isSuccess !== undefined && (
-                <div className="w-auto mr-3">
+                <div className="w-auto mr-3 mt-0.5">
                   {isSuccess ? <IconSuccess className="text-emerald" /> : <IconError />}
                 </div>
               )}


### PR DESCRIPTION
## Summary

Align top vertically, centre horizontally for overlay title bar

## Changes

flex content-center items-center to flex content-center items-start

## Issues

NIL
