### PR TITLE
feat: feedback widget

### DIFF
--- a/src/components/FeedbackWidget/FeedbackWidget.stories.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidget.stories.tsx
@@ -1,0 +1,61 @@
+import React, { FunctionComponent } from "react";
+import { FeedbackWidget } from "./FeedbackWidget";
+import { FeedbackWidgetText } from "./FeedbackWidgetText";
+
+export default {
+  title: "FeedbackWidget/FeedbackWidget",
+  component: FeedbackWidget,
+  parameters: {
+    componentSubtitle: "Feedback widget",
+  },
+};
+
+export const Default: FunctionComponent = () => {
+  return (
+    <>
+      <div style={{ width: "320px" }}>
+        <p className="mb-4">
+          Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+          aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+          dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit
+          amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam
+          aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit
+          laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea
+          voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+          pariatur.
+        </p>
+        <p className="mb-4">
+          Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+          aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+          dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit
+          amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam
+          aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit
+          laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea
+          voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+          pariatur.
+        </p>
+        <p className="mb-4">
+          Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+          aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+          dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit
+          amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam
+          aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit
+          laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea
+          voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla
+          pariatur.
+        </p>
+      </div>
+      <FeedbackWidget>
+        <FeedbackWidgetText
+          positiveFeedbackUrl="https://example.com/yes"
+          positiveFeedbackHandle={() => {}}
+          negativeFeedbackUrl="https://example.com/no"
+          negativeFeedbackHandle={() => {}}
+        />
+      </FeedbackWidget>
+    </>
+  );
+};

--- a/src/components/FeedbackWidget/FeedbackWidget.test.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidget.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { FeedbackWidget } from "./FeedbackWidget";
+
+describe("FeedbackWidget", () => {
+  it("should have correct feedback title", () => {
+    render(<FeedbackWidget />);
+    expect(screen.getByText("Feedback")).toBeInTheDocument();
+  });
+
+  it("should not show feedback by default", () => {
+    render(<FeedbackWidget />);
+    expect(screen.getByTestId("feedback")).toHaveClass("opacity-0");
+  });
+
+  it("should only show feedback when scrolled up", () => {
+    render(<FeedbackWidget />);
+
+    act(() => {
+      fireEvent.scroll(window, { target: { scrollY: 100 } });
+      expect(screen.getByTestId("feedback")).toHaveClass("opacity-0");
+    });
+
+    act(() => {
+      fireEvent.scroll(window, { target: { scrollY: 99 } });
+      expect(screen.getByTestId("feedback")).not.toHaveClass("opacity-0");
+    });
+  });
+});

--- a/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,0 +1,79 @@
+import React, { FunctionComponent, useState, useEffect, useCallback, useRef } from "react";
+
+type ScrollDirection = "up" | "down";
+
+export const FeedbackWidget: FunctionComponent = ({ children }) => {
+  const [scrollDirection, setScrollDirection] = useState<ScrollDirection>("down");
+  const isScrollDown = scrollDirection === "down";
+  const refScrollTopLast = useRef(0);
+
+  const onScroll = useCallback(() => {
+    const scrollTopCurr = document.body.scrollTop || document.documentElement.scrollTop;
+    setScrollDirection(scrollTopCurr > refScrollTopLast.current ? "down" : "up");
+    refScrollTopLast.current = scrollTopCurr <= 0 ? 0 : scrollTopCurr;
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("scroll", onScroll);
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, [onScroll]);
+
+  return (
+    <div
+      className={`transition-all delay-150 duration-200 ease-out fixed text-center text-white rounded-xl p-6 bg-cerulean-500 z-50 left-4 lg:left-auto lg:right-24 ${
+        isScrollDown ? "scale-90 opacity-0" : ""
+      }`}
+      style={{ bottom: "1.3rem", maxWidth: "220px" }}
+      data-testid="feedback"
+    >
+      <div className="mb-2">
+        <svg
+          className="mx-auto"
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18.6956 18.6957H10.0869C5.21737 18.6957 1.30432 14.6957 1.30432 9.91305C1.30432 5.13044 5.13041 1.30435 9.91302 1.30435H10.0869C14.8695 1.30435 18.6956 5.13044 18.6956 9.91305V18.6957Z"
+            stroke="white"
+            strokeWidth="2"
+            strokeMiterlimit="10"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M5.91296 6.17386H13.9999"
+            stroke="white"
+            strokeWidth="2"
+            strokeMiterlimit="10"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M5.91296 9.73904H13.9999"
+            stroke="white"
+            strokeWidth="2"
+            strokeMiterlimit="10"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M5.91296 13.3913H9.08729"
+            stroke="white"
+            strokeWidth="2"
+            strokeMiterlimit="10"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        <h3 className="text-lg">Feedback</h3>
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/src/components/FeedbackWidget/FeedbackWidgetText.test.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidgetText.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FeedbackWidgetText } from "./FeedbackWidgetText";
+
+describe("FeedbackWidgetText", () => {
+  it("should show default feedback text", () => {
+    render(
+      <FeedbackWidgetText
+        positiveFeedbackUrl="https://example.com/yes"
+        positiveFeedbackHandle={() => {}}
+        negativeFeedbackUrl="https://example.com/no"
+        negativeFeedbackHandle={() => {}}
+      />
+    );
+
+    expect(screen.getByText("Is this page helpful?")).toBeInTheDocument();
+  });
+
+  it("should show 'yes' feedback text with 'ideas' github url", () => {
+    render(
+      <FeedbackWidgetText
+        positiveFeedbackUrl="https://example.com/yes"
+        positiveFeedbackHandle={() => {}}
+        negativeFeedbackUrl="https://example.com/no"
+        negativeFeedbackHandle={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByText("Yes"));
+
+    expect(
+      screen.getByText("Thank you for your feedback. Do leave us a feedback on Github to help us do even better.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Github")).toHaveAttribute("href", "https://example.com/yes");
+  });
+
+  it("should show 'no' feedback text with 'improvements' github url", () => {
+    render(
+      <FeedbackWidgetText
+        positiveFeedbackUrl="https://example.com/yes"
+        positiveFeedbackHandle={() => {}}
+        negativeFeedbackUrl="https://example.com/no"
+        negativeFeedbackHandle={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByText("No"));
+
+    expect(
+      screen.getByText("We are sorry to hear that. Do leave us a feedback on Github to help us do better.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Github")).toHaveAttribute("href", "https://example.com/no");
+  });
+});

--- a/src/components/FeedbackWidget/FeedbackWidgetText.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidgetText.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import { Button, LinkButton } from "../UI/Button";
+
+type Feedback = "yes" | "no" | null;
+
+interface FeedbackWidgetTextProps {
+  positiveFeedbackUrl: string;
+  positiveFeedbackHandle?: () => void;
+  negativeFeedbackUrl: string;
+  negativeFeedbackHandle?: () => void;
+}
+
+export const FeedbackWidgetText: React.FunctionComponent<FeedbackWidgetTextProps> = ({
+  positiveFeedbackUrl,
+  positiveFeedbackHandle,
+  negativeFeedbackUrl,
+  negativeFeedbackHandle,
+}) => {
+  const [feedback, setFeedback] = useState<Feedback>(null);
+
+  switch (true) {
+    case feedback === "yes":
+      return (
+        <>
+          <p>Thank you for your feedback. Do leave us a feedback on Github to help us do even better.</p>
+          <div className="mt-4">
+            <LinkButton
+              className="bg-white text-cerulean-500 hover:bg-gray-50 mx-2 inline-block"
+              href={positiveFeedbackUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Github
+            </LinkButton>
+          </div>
+        </>
+      );
+    case feedback === "no":
+      return (
+        <>
+          <p>We are sorry to hear that. Do leave us a feedback on Github to help us do better.</p>
+          <div className="mt-4">
+            <LinkButton
+              className="bg-white text-cerulean-500 hover:bg-gray-50 mx-2 inline-block"
+              href={negativeFeedbackUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Github
+            </LinkButton>
+          </div>
+        </>
+      );
+    default:
+      return (
+        <>
+          <p>Is this page helpful?</p>
+          <div className="mt-4">
+            <Button
+              className="bg-white text-cerulean-500 hover:bg-gray-50 mx-2"
+              onClick={() => {
+                setFeedback("yes");
+                if (positiveFeedbackHandle) positiveFeedbackHandle();
+              }}
+            >
+              Yes
+            </Button>
+            <Button
+              className="bg-white text-cerulean-500 hover:bg-gray-50 mx-2"
+              onClick={() => {
+                setFeedback("no");
+                if (negativeFeedbackHandle) negativeFeedbackHandle();
+              }}
+            >
+              No
+            </Button>
+          </div>
+        </>
+      );
+  }
+};

--- a/src/components/FeedbackWidget/index.tsx
+++ b/src/components/FeedbackWidget/index.tsx
@@ -1,0 +1,2 @@
+export * from "./FeedbackWidget";
+export * from "./FeedbackWidgetText";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ export * from "./common/context/OverlayContext";
 export * from "./components/AddressBook";
 export * from "./components/AddressResolver";
 export * from "./components/ErrorPage";
+export * from "./components/FeedbackWidget";
 export * from "./components/NetworkBar";
 export * from "./components/NavigationBar";
 export * from "./components/UI/BarTrack";


### PR DESCRIPTION
- feedback widget for tradetrust documentation pages
- interaction behaviour try to follow as close to docusaurus "back to top" button (on scroll up show)
- respective feedback clicks will open passed url props
- related https://github.com/TradeTrust/documentation/pull/60