### PR TITLE
fix: deprecate ropsten and rinkeby

### DIFF
--- a/src/components/AddressBook/AddressBook.stories.tsx
+++ b/src/components/AddressBook/AddressBook.stories.tsx
@@ -12,7 +12,7 @@ export const DefaultAddressBook = (): ReactElement => {
 
   return (
     <AddressBook
-      network="ropsten"
+      network="goerli"
       onAddressSelect={(address: string) => {
         console.log(address);
       }}
@@ -59,7 +59,7 @@ export const PopulatedLocalAddressBook = (): ReactElement => {
       onAddressSelect={(address: string) => {
         console.log(address);
       }}
-      network="ropsten"
+      network="goerli"
     />
   );
 };
@@ -98,7 +98,7 @@ export const PopulatedThirdpartyAddressBook = (): ReactElement => {
       onAddressSelect={(address: string) => {
         console.log(address);
       }}
-      network="ropsten"
+      network="goerli"
     />
   );
 };
@@ -137,7 +137,7 @@ export const ThirdpartyAddressBookNoEntityLookup = (): ReactElement => {
       onAddressSelect={(address: string) => {
         console.log(address);
       }}
-      network="ropsten"
+      network="goerli"
     />
   );
 };

--- a/src/components/AddressBook/AddressBookTableRow.tsx
+++ b/src/components/AddressBook/AddressBookTableRow.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { ExternalLink } from "react-feather";
-import { makeEtherscanAddressURL } from "../../utils";
+import { makeAddressURL } from "../../utils";
 
 interface AddressBookTableRowProps {
   onAddressSelect: () => void;
@@ -17,7 +17,7 @@ interface AddressBookEtherscanLinkProps {
 }
 
 const AddressBookEtherscanLink: FunctionComponent<AddressBookEtherscanLinkProps> = ({ address, network }) => {
-  const addressHref = makeEtherscanAddressURL(address, network);
+  const addressHref = makeAddressURL(address, network);
   return (
     <a
       className="inline-block text-cerulean-300 hover:text-cerulean-800"

--- a/src/components/AddressBook/OverlayAddressBook.stories.tsx
+++ b/src/components/AddressBook/OverlayAddressBook.stories.tsx
@@ -59,7 +59,7 @@ export const PopulatedThirdpartyAddressBook = (): ReactElement => {
       <OverlayDemo buttonText="Populated third party address book">
         <OverlayAddressBook
           onAddressSelected={(address) => window.alert(`${address} was selected!`)}
-          network="ropsten"
+          network="goerli"
           title="Address Book"
         />
       </OverlayDemo>

--- a/src/components/NetworkBar/NetworkBar.stories.tsx
+++ b/src/components/NetworkBar/NetworkBar.stories.tsx
@@ -11,7 +11,7 @@ export default {
 };
 
 export const Default = (): ReactElement => {
-  const [network, setNetwork] = useState("ropsten");
+  const [network, setNetwork] = useState("goerli");
 
   return (
     <div>
@@ -21,11 +21,11 @@ export const Default = (): ReactElement => {
       </NetworkBar>
       {/* To Simulate change of config file or network by pressing the buttons */}
       <div className="mt-6 flex justify-around max-w-md mx-auto">
-        <Button className="bg-forest-500 text-white hover:bg-forest-700" onClick={() => setNetwork("ropsten")}>
-          Change to Ropsten
+        <Button className="bg-forest-500 text-white hover:bg-forest-700" onClick={() => setNetwork("goerli")}>
+          Change to Goerli
         </Button>
-        <Button className="bg-tangerine-500 text-white hover:bg-tangerine-800" onClick={() => setNetwork("rinkeby")}>
-          Change to Rinkeby
+        <Button className="bg-tangerine-500 text-white hover:bg-tangerine-800" onClick={() => setNetwork("sepolia")}>
+          Change to Sepolia
         </Button>
       </div>
     </div>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,6 @@ const getBaseUrl = (network: string): string => {
   return network.includes("matic") ? getPolygonscanBaseUrl(network) : getEtherscanBaseUrl(network);
 };
 
-export const makeEtherscanAddressURL = (address: string, network: string): string => {
+export const makeAddressURL = (address: string, network: string): string => {
   return `${getBaseUrl(network)}address/${address}`;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,14 @@ const getEtherscanBaseUrl = (network: string): string => {
   return `https://${network === "mainnet" ? "" : network + "."}etherscan.io/`;
 };
 
+const getPolygonscanBaseUrl = (network: string): string => {
+  return `https://${network === "matic" ? "" : "mumbai."}polygonscan.com/`;
+};
+
+const getBaseUrl = (network: string): string => {
+  return network.includes("matic") ? getPolygonscanBaseUrl(network) : getEtherscanBaseUrl(network);
+};
+
 export const makeEtherscanAddressURL = (address: string, network: string): string => {
-  return `${getEtherscanBaseUrl(network)}address/${address}`;
+  return `${getBaseUrl(network)}address/${address}`;
 };

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,14 +1,14 @@
-import { makeEtherscanAddressURL } from "./index";
+import { makeAddressURL } from "./index";
 
-describe("makeEtherscanAddressURL", () => {
+describe("makeAddressURL", () => {
   it("should get the correct url, given an ethereum network and address", () => {
-    expect(makeEtherscanAddressURL("0x123", "mainnet")).toStrictEqual("https://etherscan.io/address/0x123");
-    expect(makeEtherscanAddressURL("0x123", "goerli")).toStrictEqual("https://goerli.etherscan.io/address/0x123");
-    expect(makeEtherscanAddressURL("0x123", "sepolia")).toStrictEqual("https://sepolia.etherscan.io/address/0x123");
+    expect(makeAddressURL("0x123", "mainnet")).toStrictEqual("https://etherscan.io/address/0x123");
+    expect(makeAddressURL("0x123", "goerli")).toStrictEqual("https://goerli.etherscan.io/address/0x123");
+    expect(makeAddressURL("0x123", "sepolia")).toStrictEqual("https://sepolia.etherscan.io/address/0x123");
   });
 
   it("should get the correct url, given a polygon network and address", () => {
-    expect(makeEtherscanAddressURL("0x123", "matic")).toStrictEqual("https://polygonscan.com/address/0x123");
-    expect(makeEtherscanAddressURL("0x123", "maticmum")).toStrictEqual("https://mumbai.polygonscan.com/address/0x123");
+    expect(makeAddressURL("0x123", "matic")).toStrictEqual("https://polygonscan.com/address/0x123");
+    expect(makeAddressURL("0x123", "maticmum")).toStrictEqual("https://mumbai.polygonscan.com/address/0x123");
   });
 });

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,14 @@
+import { makeEtherscanAddressURL } from "./index";
+
+describe("makeEtherscanAddressURL", () => {
+  it("should get the correct url, given an ethereum network and address", () => {
+    expect(makeEtherscanAddressURL("0x123", "mainnet")).toStrictEqual("https://etherscan.io/address/0x123");
+    expect(makeEtherscanAddressURL("0x123", "goerli")).toStrictEqual("https://goerli.etherscan.io/address/0x123");
+    expect(makeEtherscanAddressURL("0x123", "sepolia")).toStrictEqual("https://sepolia.etherscan.io/address/0x123");
+  });
+
+  it("should get the correct url, given a polygon network and address", () => {
+    expect(makeEtherscanAddressURL("0x123", "matic")).toStrictEqual("https://polygonscan.com/address/0x123");
+    expect(makeEtherscanAddressURL("0x123", "maticmum")).toStrictEqual("https://mumbai.polygonscan.com/address/0x123");
+  });
+});


### PR DESCRIPTION
## Summary

Deprecate all instances of ropsten and rinkeby.

## Changes

- Text change to goerli and sepolia to reduce the confusion in future
- fix `makeAddressURL()` to generate polygonscan url too

## Issues

https://www.pivotaltracker.com/n/projects/2424361/stories/183587058
