### PR TITLE
fix: move bg color so as to not have css clash

### DIFF
--- a/src/components/UI/Overlay/OverlayContent/DocumentTransferMessage.tsx
+++ b/src/components/UI/Overlay/OverlayContent/DocumentTransferMessage.tsx
@@ -90,7 +90,7 @@ export const DocumentTransferMessage: FunctionComponent<DocumentTransferMessageP
   };
 
   return (
-    <OverlayContent className="max-w-md" {...props}>
+    <OverlayContent className="max-w-md bg-white" {...props}>
       <div className="flex-1 mb-4">{children}</div>
       <div className="flex mx-0">
         <div className="flex w-full col-auto justify-center">{documentTransferButton()}</div>

--- a/src/components/UI/Overlay/OverlayContent/OverlayContent.tsx
+++ b/src/components/UI/Overlay/OverlayContent/OverlayContent.tsx
@@ -44,7 +44,7 @@ export const OverlayContent: FunctionComponent<OverlayContentProps> = ({
     <>
       {isOverlayVisible && (
         <div
-          className={`relative flex flex-col p-5 bg-white rounded-xl shadow-lg overflow-auto h-auto ${className}`}
+          className={`relative flex flex-col p-5 rounded-xl shadow-lg overflow-auto h-auto ${className}`}
           {...props}
           style={style}
         >

--- a/src/components/UI/Overlay/OverlayContent/Textual.tsx
+++ b/src/components/UI/Overlay/OverlayContent/Textual.tsx
@@ -3,7 +3,7 @@ import { OverlayContent, OverlayContentProps } from "./index";
 
 export const Textual: React.FunctionComponent<OverlayContentProps> = ({ children, ...props }) => {
   return (
-    <OverlayContent className="max-w-6xl" {...props}>
+    <OverlayContent className="max-w-6xl bg-white" {...props}>
       {children}
     </OverlayContent>
   );

--- a/src/components/UI/Overlay/OverlayContent/Youtube.tsx
+++ b/src/components/UI/Overlay/OverlayContent/Youtube.tsx
@@ -7,7 +7,7 @@ interface YoutubeProps extends OverlayContentProps {
 
 export const Youtube: FunctionComponent<YoutubeProps> = ({ youtubeId, ...props }) => {
   return (
-    <OverlayContent className="max-w-6xl" {...props}>
+    <OverlayContent className="max-w-6xl bg-white" {...props}>
       <div className="aspect-16-9">
         <iframe
           className="absolute top-0 left-0 w-full h-full p-0 m-0 border-0"


### PR DESCRIPTION
## Summary

Fix css clash issue in TT-web

## Changes

- Remove bg-white from overlayContext component, so that user can define the bg color at the custom component level, instead of preset as white.

